### PR TITLE
Remove invalid characters from filename when using the prompt in the filename

### DIFF
--- a/modules/nodes/node.py
+++ b/modules/nodes/node.py
@@ -328,7 +328,7 @@ class SaveImageWithMetaData:
                 prompt = pnginfo_dict.get(prompt_key, "")
                 if not prompt:
                     print_warning(f"{prompt_key} not found in pnginfo_dict!")
-                prompt = prompt.replace("\n", " ")
+                prompt = re.sub(r'[^a-zA-Z0-9 ._-]', '', prompt)
                 length = int(parts[1]) if len(parts) > 1 and parts[1].isdigit() else None
                 filename = filename.replace(segment, prompt[:length].strip() if length else prompt.strip())
 


### PR DESCRIPTION
### Issue
When saving using the prompt formatting options (e.g. %pprompt:[n]%) it would fail to save if there was invalid characters in the prompt and would also create empty folders when coming across escaped characters.

### Solution
Use a [^a-zA-Z0-9 ._-] regex to remove everything from the filename that isn't a letter, number, a space, or a few special characters (period, underscore, and hyphen).


This is my first time submitting code so I'm hoping I'm doing it right.  The error just popped up and I figured I'd give it a shot.  I did throw a bunch of loras and escapes at it and it seems to be working perfectly now.