### PR TITLE
Fix synchronous cache access in `capture.py` for newer ComfyUI cache APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 .cache
+.vs

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,6 +1,7 @@
 import functools
 
-from .hook import pre_execute, pre_get_input_data
+from . import hook
+from .hook import pre_execute
 import execution
 
 
@@ -14,9 +15,8 @@ def prefix_function(function, prefunction):
     return run
 
 
+hook.original_get_input_data = execution.get_input_data
+
 execution.PromptExecutor.execute = prefix_function(
     execution.PromptExecutor.execute, pre_execute
 )
-
-
-execution.get_input_data = prefix_function(execution.get_input_data, pre_get_input_data)

--- a/modules/capture.py
+++ b/modules/capture.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import inspect
 from collections import defaultdict
 from . import hook
 from .defs.captures import CAPTURE_FIELD_LIST
@@ -21,23 +22,38 @@ class OutputCacheCompat:
     def __init__(self, cache):
         self._cache = cache
 
-    def get_output_cache(self, input_unique_id, unique_id=None):
-        # For version 0.3.67 and newer
-        if hasattr(self._cache, "get"):
-            return self._cache.get(input_unique_id)
+    def _lookup_cached(self, input_unique_id, unique_id=None):
+        # Newer ComfyUI cache objects expose an async get() and a sync get_local().
+        # This shim is used from synchronous metadata capture code, so prefer the
+        # synchronous accessors and reject awaitable results from get().
+        get_local = getattr(self._cache, "get_local", None)
+        if callable(get_local):
+            return get_local(input_unique_id)
+
+        get_cache = getattr(self._cache, "get_cache", None)
+        if callable(get_cache):
+            try:
+                return get_cache(input_unique_id, unique_id)
+            except TypeError:
+                return get_cache(input_unique_id)
+
+        getter = getattr(self._cache, "get", None)
+        if callable(getter):
+            result = getter(input_unique_id)
+            if not inspect.isawaitable(result):
+                return result
+
         return getattr(self._cache, "outputs", {}).get(input_unique_id, None)
 
+    def get_output_cache(self, input_unique_id, unique_id=None):
+        return self._lookup_cached(input_unique_id, unique_id)
+
     def get(self, input_unique_id):
-        # For version 0.3.66 and lower
-        if hasattr(self._cache, "get"):
-            return self._cache.get(input_unique_id)
-        return getattr(self._cache, "outputs", {}).get(input_unique_id, None)
-    
+        return self._lookup_cached(input_unique_id)
+
     # fix: https://github.com/edelvarden/comfyui_image_metadata_extension/issues/67
     def get_cache(self, input_unique_id, unique_id=None):
-        if hasattr(self._cache, "get_cache"):
-            return self._cache.get_cache(input_unique_id, unique_id)
-        return self.get_output_cache(input_unique_id, unique_id)
+        return self._lookup_cached(input_unique_id, unique_id)
 
 
 class Capture:

--- a/modules/capture.py
+++ b/modules/capture.py
@@ -80,11 +80,6 @@ class Capture:
                 print_warning(f"Skipping malformed prompt node {node_id!r} while generating metadata")
                 continue
 
-            obj_class = NODE_CLASS_MAPPINGS.get(class_type)
-            if obj_class is None:
-                print_warning(f"Skipping metadata for unknown node class {class_type!r} at node {node_id}")
-                continue
-
             # Process field data mappings only for node classes that can contribute
             # metadata. Resolving full input_data for every prompt node can pull
             # large cached IMAGE/LATENT tensors through ComfyUI's cache API during
@@ -94,8 +89,13 @@ class Capture:
             if not metas:
                 continue
 
-            get_input_data_func = hook.original_get_input_data or __import__("execution").get_input_data
+            obj_class = NODE_CLASS_MAPPINGS.get(class_type)
+            if obj_class is None:
+                print_warning(f"Skipping metadata for unknown node class {class_type!r} at node {node_id}")
+                continue
+
             try:
+                get_input_data_func = hook.original_get_input_data or __import__("execution").get_input_data
                 input_data = get_input_data_func(
                     node_inputs, obj_class, node_id, outputs, DynamicPrompt(prompt), extra_data
                 )

--- a/modules/capture.py
+++ b/modules/capture.py
@@ -92,11 +92,25 @@ class Capture:
             )
 
             for meta, field_data in metas.items():
-                # Skip invalidated nodes
-                if field_data.get("validate") and not field_data["validate"](
-                    node_id, obj, prompt, extra_data, outputs, input_data
-                ):
-                    continue
+                # Skip invalidated nodes. Metadata capture must not abort image
+                # saving if a validator fails on stale bytecode, a changed prompt
+                # shape, or a third-party node with unexpected metadata.
+                validator = field_data.get("validate")
+                if validator:
+                    try:
+                        valid = validator(
+                            node_id, obj, prompt, extra_data, outputs, input_data
+                        )
+                    except Exception as e:
+                        print_warning(
+                            "Skipping metadata field after validator failure "
+                            f"for node {node_id} ({class_type}), "
+                            f"validator={getattr(validator, '__name__', repr(validator))}: {e}"
+                        )
+                        continue
+
+                    if not valid:
+                        continue
 
                 # Initialize list for meta if not exists
                 if meta not in inputs:

--- a/modules/capture.py
+++ b/modules/capture.py
@@ -73,9 +73,17 @@ class Capture:
             outputs = None
 
         for node_id, obj in prompt.items():
-            class_type = obj["class_type"]
-            obj_class = NODE_CLASS_MAPPINGS[class_type]
-            node_inputs = obj["inputs"]
+            try:
+                class_type = obj.get("class_type")
+                node_inputs = obj.get("inputs") or {}
+            except AttributeError:
+                print_warning(f"Skipping malformed prompt node {node_id!r} while generating metadata")
+                continue
+
+            obj_class = NODE_CLASS_MAPPINGS.get(class_type)
+            if obj_class is None:
+                print_warning(f"Skipping metadata for unknown node class {class_type!r} at node {node_id}")
+                continue
 
             # Process field data mappings only for node classes that can contribute
             # metadata. Resolving full input_data for every prompt node can pull
@@ -87,54 +95,51 @@ class Capture:
                 continue
 
             get_input_data_func = hook.original_get_input_data or __import__("execution").get_input_data
-            input_data = get_input_data_func(
-                node_inputs, obj_class, node_id, outputs, DynamicPrompt(prompt), extra_data
-            )
+            try:
+                input_data = get_input_data_func(
+                    node_inputs, obj_class, node_id, outputs, DynamicPrompt(prompt), extra_data
+                )
+            except Exception as e:
+                print_warning(f"Skipping metadata for node {node_id} ({class_type}): input resolution failed: {e}")
+                continue
 
             for meta, field_data in metas.items():
-                # Skip invalidated nodes. Metadata capture must not abort image
-                # saving if a validator fails on stale bytecode, a changed prompt
-                # shape, or a third-party node with unexpected metadata.
-                validator = field_data.get("validate")
-                if validator:
-                    try:
-                        valid = validator(
+                try:
+                    # Skip invalidated nodes. Metadata capture must not abort image
+                    # saving if a validator fails on stale bytecode, a changed prompt
+                    # shape, or a third-party node with unexpected metadata.
+                    validator = field_data.get("validate")
+                    if validator and not validator(
                             node_id, obj, prompt, extra_data, outputs, input_data
-                        )
-                    except Exception as e:
-                        print_warning(
-                            "Skipping metadata field after validator failure "
-                            f"for node {node_id} ({class_type}), "
-                            f"validator={getattr(validator, '__name__', repr(validator))}: {e}"
-                        )
+                    ):
                         continue
 
-                    if not valid:
+                    # Initialize list for meta if not exists
+                    if meta not in inputs:
+                        inputs[meta] = []
+
+                    # Get field value or selector
+                    value = field_data.get("value")
+                    if value is not None:
+                        inputs[meta].append((node_id, value))
                         continue
 
-                # Initialize list for meta if not exists
-                if meta not in inputs:
-                    inputs[meta] = []
+                    selector = field_data.get("selector")
+                    if selector:
+                        v = selector(node_id, obj, prompt, extra_data, outputs, input_data)
+                        cls._append_value(inputs, meta, node_id, v)
+                        continue
 
-                # Get field value or selector
-                value = field_data.get("value")
-                if value is not None:
-                    inputs[meta].append((node_id, value))
+                    # Fetch and process value from field_name
+                    field_name = field_data["field_name"]
+                    value = input_data[0].get(field_name)
+                    if value is not None:
+                        format_func = field_data.get("format")
+                        v = cls._apply_formatting(value, input_data, format_func)
+                        cls._append_value(inputs, meta, node_id, v)
+                except Exception as e:
+                    print_warning(f"Skipping metadata field {meta} for node {node_id} ({class_type}): {e}")
                     continue
-
-                selector = field_data.get("selector")
-                if selector:
-                    v = selector(node_id, obj, prompt, extra_data, outputs, input_data)
-                    cls._append_value(inputs, meta, node_id, v)
-                    continue
-
-                # Fetch and process value from field_name
-                field_name = field_data["field_name"]
-                value = input_data[0].get(field_name)
-                if value is not None:
-                    format_func = field_data.get("format")
-                    v = cls._apply_formatting(value, input_data, format_func)
-                    cls._append_value(inputs, meta, node_id, v)
 
         return inputs
 

--- a/modules/capture.py
+++ b/modules/capture.py
@@ -11,7 +11,6 @@ from .utils.log import print_warning
 
 from nodes import NODE_CLASS_MAPPINGS
 from .trace import Trace
-from execution import get_input_data
 from comfy_execution.graph import DynamicPrompt
 
 
@@ -78,45 +77,50 @@ class Capture:
             obj_class = NODE_CLASS_MAPPINGS[class_type]
             node_inputs = obj["inputs"]
 
-            input_data = get_input_data(
+            # Process field data mappings only for node classes that can contribute
+            # metadata. Resolving full input_data for every prompt node can pull
+            # large cached IMAGE/LATENT tensors through ComfyUI's cache API during
+            # the save node, which makes the output node unnecessarily expensive
+            # and can leave the UI waiting even after the image file appears.
+            metas = CAPTURE_FIELD_LIST.get(class_type)
+            if not metas:
+                continue
+
+            get_input_data_func = hook.original_get_input_data or __import__("execution").get_input_data
+            input_data = get_input_data_func(
                 node_inputs, obj_class, node_id, outputs, DynamicPrompt(prompt), extra_data
             )
 
-            # Process field data mappings for the captured inputs
-            for node_class, metas in CAPTURE_FIELD_LIST.items():
-                if class_type != node_class:
+            for meta, field_data in metas.items():
+                # Skip invalidated nodes
+                if field_data.get("validate") and not field_data["validate"](
+                    node_id, obj, prompt, extra_data, outputs, input_data
+                ):
                     continue
 
-                for meta, field_data in metas.items():
-                    # Skip invalidated nodes
-                    if field_data.get("validate") and not field_data["validate"](
-                        node_id, obj, prompt, extra_data, outputs, input_data
-                    ):
-                        continue
+                # Initialize list for meta if not exists
+                if meta not in inputs:
+                    inputs[meta] = []
 
-                    # Initialize list for meta if not exists
-                    if meta not in inputs:
-                        inputs[meta] = []
+                # Get field value or selector
+                value = field_data.get("value")
+                if value is not None:
+                    inputs[meta].append((node_id, value))
+                    continue
 
-                    # Get field value or selector
-                    value = field_data.get("value")
-                    if value is not None:
-                        inputs[meta].append((node_id, value))
-                        continue
+                selector = field_data.get("selector")
+                if selector:
+                    v = selector(node_id, obj, prompt, extra_data, outputs, input_data)
+                    cls._append_value(inputs, meta, node_id, v)
+                    continue
 
-                    selector = field_data.get("selector")
-                    if selector:
-                        v = selector(node_id, obj, prompt, extra_data, outputs, input_data)
-                        cls._append_value(inputs, meta, node_id, v)
-                        continue
-
-                    # Fetch and process value from field_name
-                    field_name = field_data["field_name"]
-                    value = input_data[0].get(field_name)
-                    if value is not None:
-                        format_func = field_data.get("format")
-                        v = cls._apply_formatting(value, input_data, format_func)
-                        cls._append_value(inputs, meta, node_id, v)
+                # Fetch and process value from field_name
+                field_name = field_data["field_name"]
+                value = input_data[0].get(field_name)
+                if value is not None:
+                    format_func = field_data.get("format")
+                    v = cls._apply_formatting(value, input_data, format_func)
+                    cls._append_value(inputs, meta, node_id, v)
 
         return inputs
 

--- a/modules/defs/validators.py
+++ b/modules/defs/validators.py
@@ -1,6 +1,7 @@
 from collections import deque
 
 from .samplers import SAMPLERS
+from comfy_execution.graph_utils import is_link
 
 
 def is_positive_prompt(node_id, obj, prompt, extra_data, outputs, input_data_all):
@@ -17,19 +18,32 @@ def _get_node_id_list(prompt, field_name):
         for sampler_type, field_map in SAMPLERS.items():
             if node["class_type"] == sampler_type:
                 # There are nodes between "KSampler" and "CLIP Text Encode" in the SD3 workflow
+                visited = set()
                 d = deque()
-                if field_name in field_map and field_map[field_name] in node["inputs"]:
-                    d.append(node["inputs"][field_map[field_name]][0])
+                if field_name in field_map:
+                    link_value = node["inputs"].get(field_map[field_name])
+                    if is_link(link_value):
+                        upstream_id = link_value[0]
+                        if upstream_id in prompt:
+                            d.append(upstream_id)
+
                 while d:
                     nid2 = d.popleft()
+                    if nid2 in visited:
+                        continue
+                    visited.add(nid2)
+
                     if nid2 not in prompt:
                         continue
+
                     class_type = prompt[nid2]["class_type"]
                     if "CLIPTextEncode" in class_type:
                         node_id_list[nid] = nid2
                         break
-                    for k, v in prompt[nid2]["inputs"].items():
-                        if isinstance(v, list) and v:
-                            d.append(v[0])
+                    for v in prompt[nid2].get("inputs", {}).values():
+                        if is_link(v):
+                            upstream_id = v[0]
+                            if upstream_id in prompt and upstream_id not in visited:
+                                d.append(upstream_id)
 
     return list(node_id_list.values())

--- a/modules/defs/validators.py
+++ b/modules/defs/validators.py
@@ -1,74 +1,53 @@
-import logging
-from collections import deque
+from __future__ import annotations
+
+from collections.abc import Mapping
 
 from .samplers import SAMPLERS
 
-try:
-    from comfy_execution.graph_utils import is_link as _comfy_is_link
-except ImportError:
-    _comfy_is_link = None
 
-logger = logging.getLogger(__name__)
+_MAX_PROMPT_NODES = 8192
 
 
 def is_positive_prompt(node_id, obj, prompt, extra_data, outputs, input_data_all):
-    return _same_node_id(node_id, _get_node_id_list(prompt, "positive"))
+    return _node_is_directly_connected_to_side(prompt, node_id, "positive")
 
 
 def is_negative_prompt(node_id, obj, prompt, extra_data, outputs, input_data_all):
-    return _same_node_id(node_id, _get_node_id_list(prompt, "negative"))
+    return _node_is_directly_connected_to_side(prompt, node_id, "negative")
 
 
-def _same_node_id(node_id, node_ids):
-    node_id = str(node_id)
-    return any(str(candidate) == node_id for candidate in node_ids)
+def _prompt_items(prompt):
+    """Return a bounded prompt snapshot for metadata-only validation."""
+    if not isinstance(prompt, Mapping):
+        return ()
 
-
-def _prompt_dict(prompt):
-    return prompt if isinstance(prompt, dict) else {}
-
-
-def _get_node(prompt, node_id):
-    prompt = _prompt_dict(prompt)
-    if node_id in prompt:
-        return prompt[node_id]
-    str_node_id = str(node_id)
-    if str_node_id in prompt:
-        return prompt[str_node_id]
     try:
-        int_node_id = int(str_node_id)
-    except (TypeError, ValueError):
-        return None
-    return prompt.get(int_node_id)
+        return tuple(prompt.items())[:_MAX_PROMPT_NODES]
+    except Exception:
+        return ()
 
 
-def _get_inputs(node):
-    if not isinstance(node, dict):
+def _inputs(node):
+    if not isinstance(node, Mapping):
         return {}
-    inputs = node.get("inputs", {})
-    return inputs if isinstance(inputs, dict) else {}
+
+    inputs = node.get("inputs") or {}
+    return inputs if isinstance(inputs, Mapping) else {}
 
 
-def _get_class_type(node):
-    if not isinstance(node, dict):
+def _class_type(node):
+    if not isinstance(node, Mapping):
         return ""
-    class_type = node.get("class_type", "")
-    return class_type if isinstance(class_type, str) else str(class_type)
+
+    value = node.get("class_type", "")
+    return value if isinstance(value, str) else str(value)
 
 
 def _is_link(value):
-    if _comfy_is_link is not None:
-        try:
-            if _comfy_is_link(value):
-                return True
-        except Exception as e:
-            logger.debug("ComfyUI is_link failed; falling back to local link check: %s", e)
-
     return (
         isinstance(value, (list, tuple))
-        and len(value) == 2
+        and len(value) >= 2
         and isinstance(value[0], (str, int))
-        and isinstance(value[1], int)
     )
 
 
@@ -78,96 +57,55 @@ def _linked_node_id(value):
     return str(value[0])
 
 
-def _iter_linked_node_ids(inputs):
-    for value in inputs.values():
-        linked_node_id = _linked_node_id(value)
-        if linked_node_id is not None:
-            yield linked_node_id
+def _sampler_side_input_names(field_name):
+    names = {field_name}
 
+    if not isinstance(SAMPLERS, Mapping):
+        return names
 
-def _looks_like_prompt_encode_node(node):
-    class_type = _get_class_type(node)
-    class_type_lower = class_type.lower()
-    return (
-        "cliptextencode" in class_type_lower
-        or "textencode" in class_type_lower
-        or class_type in {"CLIPTextEncodeWithBreak", "AdvancedCLIPTextEncodeWithBreak"}
-    )
+    try:
+        sampler_items = tuple(SAMPLERS.items())
+    except Exception:
+        return names
 
-
-def _walk_upstream_prompt_nodes(prompt, start_node_id):
-    prompt = _prompt_dict(prompt)
-    found = []
-    queue = deque([str(start_node_id)])
-    visited = set()
-
-    while queue:
-        current_id = queue.popleft()
-        if current_id in visited:
-            continue
-        visited.add(current_id)
-
-        current_node = _get_node(prompt, current_id)
-        if current_node is None:
+    for _sampler_type, field_map in sampler_items:
+        if not isinstance(field_map, Mapping):
             continue
 
-        if _looks_like_prompt_encode_node(current_node):
-            found.append(current_id)
-            # Keep walking: wrapper prompt nodes can feed into CLIPTextEncode nodes,
-            # and the nearest/trace filter will decide which metadata survives.
+        input_name = field_map.get(field_name)
+        if isinstance(input_name, str) and input_name:
+            names.add(input_name)
 
-        for upstream_id in _iter_linked_node_ids(_get_inputs(current_node)):
-            if upstream_id not in visited:
-                queue.append(upstream_id)
-
-    return found
+    return names
 
 
-def _iter_sampler_prompt_links(prompt, field_name):
-    prompt = _prompt_dict(prompt)
+def _node_is_directly_connected_to_side(prompt, node_id, field_name):
+    wanted = str(node_id)
+    side_input_names = _sampler_side_input_names(field_name)
 
-    # Use a snapshot because extensions mutate SAMPLERS during startup.
-    sampler_items = tuple(SAMPLERS.items()) if isinstance(SAMPLERS, dict) else ()
+    for _current_id, current_node in _prompt_items(prompt):
+        inputs = _inputs(current_node)
+        if not inputs:
+            continue
 
-    for _node_id, node in prompt.items():
-        class_type = _get_class_type(node)
-        inputs = _get_inputs(node)
-        yielded_for_node = set()
+        for input_name in side_input_names:
+            if _linked_node_id(inputs.get(input_name)) == wanted:
+                return True
 
-        for sampler_type, field_map in sampler_items:
-            if class_type != sampler_type or not isinstance(field_map, dict):
-                continue
+        class_type = _class_type(current_node)
+        if not class_type or not isinstance(SAMPLERS, Mapping):
+            continue
 
-            input_name = field_map.get(field_name)
-            if not input_name:
-                continue
+        try:
+            field_map = SAMPLERS.get(class_type)
+        except Exception:
+            field_map = None
 
-            linked_node_id = _linked_node_id(inputs.get(input_name))
-            if linked_node_id is not None:
-                yielded_for_node.add(linked_node_id)
-                yield linked_node_id
+        if not isinstance(field_map, Mapping):
+            continue
 
-        # Fallback for custom sampler/guider nodes that expose direct
-        # positive/negative conditioning inputs but are not in SAMPLERS yet.
-        linked_node_id = _linked_node_id(inputs.get(field_name))
-        if linked_node_id is not None and linked_node_id not in yielded_for_node:
-            yield linked_node_id
+        input_name = field_map.get(field_name)
+        if isinstance(input_name, str) and _linked_node_id(inputs.get(input_name)) == wanted:
+            return True
 
-
-def _get_node_id_list(prompt, field_name):
-    prompt = _prompt_dict(prompt)
-    node_id_list = []
-    seen = set()
-
-    for linked_node_id in _iter_sampler_prompt_links(prompt, field_name):
-        candidates = _walk_upstream_prompt_nodes(prompt, linked_node_id)
-        if not candidates:
-            candidates = [linked_node_id]
-
-        for candidate in candidates:
-            candidate = str(candidate)
-            if candidate not in seen:
-                seen.add(candidate)
-                node_id_list.append(candidate)
-
-    return node_id_list
+    return False

--- a/modules/defs/validators.py
+++ b/modules/defs/validators.py
@@ -1,11 +1,14 @@
+import logging
 from collections import deque
 
 from .samplers import SAMPLERS
 
 try:
     from comfy_execution.graph_utils import is_link as _comfy_is_link
-except Exception:
+except ImportError:
     _comfy_is_link = None
+
+logger = logging.getLogger(__name__)
 
 
 def is_positive_prompt(node_id, obj, prompt, extra_data, outputs, input_data_all):
@@ -58,8 +61,8 @@ def _is_link(value):
         try:
             if _comfy_is_link(value):
                 return True
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("ComfyUI is_link failed; falling back to local link check: %s", e)
 
     return (
         isinstance(value, (list, tuple))
@@ -126,7 +129,7 @@ def _iter_sampler_prompt_links(prompt, field_name):
     # Use a snapshot because extensions mutate SAMPLERS during startup.
     sampler_items = tuple(SAMPLERS.items()) if isinstance(SAMPLERS, dict) else ()
 
-    for node_id, node in prompt.items():
+    for _node_id, node in prompt.items():
         class_type = _get_class_type(node)
         inputs = _get_inputs(node)
         yielded_for_node = set()

--- a/modules/defs/validators.py
+++ b/modules/defs/validators.py
@@ -57,51 +57,28 @@ def _linked_node_id(value):
     return str(value[0])
 
 
-def _sampler_side_input_names(field_name):
-    names = {field_name}
-
-    if not isinstance(SAMPLERS, Mapping):
-        return names
+def _sampler_field_map(class_type):
+    if not class_type or not isinstance(SAMPLERS, Mapping):
+        return None
 
     try:
-        sampler_items = tuple(SAMPLERS.items())
+        field_map = SAMPLERS.get(class_type)
     except Exception:
-        return names
+        return None
 
-    for _sampler_type, field_map in sampler_items:
-        if not isinstance(field_map, Mapping):
-            continue
-
-        input_name = field_map.get(field_name)
-        if isinstance(input_name, str) and input_name:
-            names.add(input_name)
-
-    return names
+    return field_map if isinstance(field_map, Mapping) else None
 
 
 def _node_is_directly_connected_to_side(prompt, node_id, field_name):
     wanted = str(node_id)
-    side_input_names = _sampler_side_input_names(field_name)
 
     for _current_id, current_node in _prompt_items(prompt):
         inputs = _inputs(current_node)
         if not inputs:
             continue
 
-        for input_name in side_input_names:
-            if _linked_node_id(inputs.get(input_name)) == wanted:
-                return True
-
-        class_type = _class_type(current_node)
-        if not class_type or not isinstance(SAMPLERS, Mapping):
-            continue
-
-        try:
-            field_map = SAMPLERS.get(class_type)
-        except Exception:
-            field_map = None
-
-        if not isinstance(field_map, Mapping):
+        field_map = _sampler_field_map(_class_type(current_node))
+        if field_map is None:
             continue
 
         input_name = field_map.get(field_name)

--- a/modules/defs/validators.py
+++ b/modules/defs/validators.py
@@ -1,49 +1,170 @@
 from collections import deque
 
 from .samplers import SAMPLERS
-from comfy_execution.graph_utils import is_link
+
+try:
+    from comfy_execution.graph_utils import is_link as _comfy_is_link
+except Exception:
+    _comfy_is_link = None
 
 
 def is_positive_prompt(node_id, obj, prompt, extra_data, outputs, input_data_all):
-    return node_id in _get_node_id_list(prompt, "positive")
+    return _same_node_id(node_id, _get_node_id_list(prompt, "positive"))
 
 
 def is_negative_prompt(node_id, obj, prompt, extra_data, outputs, input_data_all):
-    return node_id in _get_node_id_list(prompt, "negative")
+    return _same_node_id(node_id, _get_node_id_list(prompt, "negative"))
+
+
+def _same_node_id(node_id, node_ids):
+    node_id = str(node_id)
+    return any(str(candidate) == node_id for candidate in node_ids)
+
+
+def _prompt_dict(prompt):
+    return prompt if isinstance(prompt, dict) else {}
+
+
+def _get_node(prompt, node_id):
+    prompt = _prompt_dict(prompt)
+    if node_id in prompt:
+        return prompt[node_id]
+    str_node_id = str(node_id)
+    if str_node_id in prompt:
+        return prompt[str_node_id]
+    try:
+        int_node_id = int(str_node_id)
+    except (TypeError, ValueError):
+        return None
+    return prompt.get(int_node_id)
+
+
+def _get_inputs(node):
+    if not isinstance(node, dict):
+        return {}
+    inputs = node.get("inputs", {})
+    return inputs if isinstance(inputs, dict) else {}
+
+
+def _get_class_type(node):
+    if not isinstance(node, dict):
+        return ""
+    class_type = node.get("class_type", "")
+    return class_type if isinstance(class_type, str) else str(class_type)
+
+
+def _is_link(value):
+    if _comfy_is_link is not None:
+        try:
+            if _comfy_is_link(value):
+                return True
+        except Exception:
+            pass
+
+    return (
+        isinstance(value, (list, tuple))
+        and len(value) == 2
+        and isinstance(value[0], (str, int))
+        and isinstance(value[1], int)
+    )
+
+
+def _linked_node_id(value):
+    if not _is_link(value):
+        return None
+    return str(value[0])
+
+
+def _iter_linked_node_ids(inputs):
+    for value in inputs.values():
+        linked_node_id = _linked_node_id(value)
+        if linked_node_id is not None:
+            yield linked_node_id
+
+
+def _looks_like_prompt_encode_node(node):
+    class_type = _get_class_type(node)
+    class_type_lower = class_type.lower()
+    return (
+        "cliptextencode" in class_type_lower
+        or "textencode" in class_type_lower
+        or class_type in {"CLIPTextEncodeWithBreak", "AdvancedCLIPTextEncodeWithBreak"}
+    )
+
+
+def _walk_upstream_prompt_nodes(prompt, start_node_id):
+    prompt = _prompt_dict(prompt)
+    found = []
+    queue = deque([str(start_node_id)])
+    visited = set()
+
+    while queue:
+        current_id = queue.popleft()
+        if current_id in visited:
+            continue
+        visited.add(current_id)
+
+        current_node = _get_node(prompt, current_id)
+        if current_node is None:
+            continue
+
+        if _looks_like_prompt_encode_node(current_node):
+            found.append(current_id)
+            # Keep walking: wrapper prompt nodes can feed into CLIPTextEncode nodes,
+            # and the nearest/trace filter will decide which metadata survives.
+
+        for upstream_id in _iter_linked_node_ids(_get_inputs(current_node)):
+            if upstream_id not in visited:
+                queue.append(upstream_id)
+
+    return found
+
+
+def _iter_sampler_prompt_links(prompt, field_name):
+    prompt = _prompt_dict(prompt)
+
+    # Use a snapshot because extensions mutate SAMPLERS during startup.
+    sampler_items = tuple(SAMPLERS.items()) if isinstance(SAMPLERS, dict) else ()
+
+    for node_id, node in prompt.items():
+        class_type = _get_class_type(node)
+        inputs = _get_inputs(node)
+        yielded_for_node = set()
+
+        for sampler_type, field_map in sampler_items:
+            if class_type != sampler_type or not isinstance(field_map, dict):
+                continue
+
+            input_name = field_map.get(field_name)
+            if not input_name:
+                continue
+
+            linked_node_id = _linked_node_id(inputs.get(input_name))
+            if linked_node_id is not None:
+                yielded_for_node.add(linked_node_id)
+                yield linked_node_id
+
+        # Fallback for custom sampler/guider nodes that expose direct
+        # positive/negative conditioning inputs but are not in SAMPLERS yet.
+        linked_node_id = _linked_node_id(inputs.get(field_name))
+        if linked_node_id is not None and linked_node_id not in yielded_for_node:
+            yield linked_node_id
 
 
 def _get_node_id_list(prompt, field_name):
-    node_id_list = {}
-    for nid, node in prompt.items():
-        for sampler_type, field_map in SAMPLERS.items():
-            if node["class_type"] == sampler_type:
-                # There are nodes between "KSampler" and "CLIP Text Encode" in the SD3 workflow
-                visited = set()
-                d = deque()
-                if field_name in field_map:
-                    link_value = node["inputs"].get(field_map[field_name])
-                    if is_link(link_value):
-                        upstream_id = link_value[0]
-                        if upstream_id in prompt:
-                            d.append(upstream_id)
+    prompt = _prompt_dict(prompt)
+    node_id_list = []
+    seen = set()
 
-                while d:
-                    nid2 = d.popleft()
-                    if nid2 in visited:
-                        continue
-                    visited.add(nid2)
+    for linked_node_id in _iter_sampler_prompt_links(prompt, field_name):
+        candidates = _walk_upstream_prompt_nodes(prompt, linked_node_id)
+        if not candidates:
+            candidates = [linked_node_id]
 
-                    if nid2 not in prompt:
-                        continue
+        for candidate in candidates:
+            candidate = str(candidate)
+            if candidate not in seen:
+                seen.add(candidate)
+                node_id_list.append(candidate)
 
-                    class_type = prompt[nid2]["class_type"]
-                    if "CLIPTextEncode" in class_type:
-                        node_id_list[nid] = nid2
-                        break
-                    for v in prompt[nid2].get("inputs", {}).values():
-                        if is_link(v):
-                            upstream_id = v[0]
-                            if upstream_id in prompt and upstream_id not in visited:
-                                d.append(upstream_id)
-
-    return list(node_id_list.values())
+    return node_id_list

--- a/modules/hook.py
+++ b/modules/hook.py
@@ -1,9 +1,6 @@
-from .nodes.node import SaveImageWithMetaData
-
 current_prompt = {}
 current_extra_data = {}
 prompt_executer = None
-current_save_image_node_id = -1
 original_get_input_data = None
 
 
@@ -15,10 +12,3 @@ def pre_execute(self, prompt, prompt_id, extra_data, execute_outputs):
     current_prompt = prompt
     current_extra_data = extra_data
     prompt_executer = self
-
-
-def pre_get_input_data(inputs, class_def, unique_id, *args):
-    global current_save_image_node_id
-
-    if class_def == SaveImageWithMetaData:
-        current_save_image_node_id = unique_id

--- a/modules/hook.py
+++ b/modules/hook.py
@@ -4,6 +4,7 @@ current_prompt = {}
 current_extra_data = {}
 prompt_executer = None
 current_save_image_node_id = -1
+original_get_input_data = None
 
 
 def pre_execute(self, prompt, prompt_id, extra_data, execute_outputs):

--- a/modules/nodes/node.py
+++ b/modules/nodes/node.py
@@ -198,10 +198,24 @@ class SaveImageWithMetaData:
         if metadata_scope in [MetadataScope.FULL, MetadataScope.PARAMETERS_ONLY] or self.needs_pnginfo_in_filename(segments):
             pnginfo_dict = pnginfo_dict or self.gen_pnginfo(prompt, prefer_nearest)
 
-        filename_prefix = self.sanitize_filename_component(
-            self.format_filename(filename_prefix, pnginfo_dict or {}, segments) + self.prefix_append,
-            default="ComfyUI",
-        )
+        raw_filename_prefix = self.format_filename(
+            filename_prefix, pnginfo_dict or {}, segments
+        ) + self.prefix_append
+        raw_prefix_parts = [p for p in re.split(r"[\\/]+", raw_filename_prefix) if p]
+
+        if raw_prefix_parts:
+            prefix_dir = self.sanitize_subdirectory_path(
+                os.path.join(*raw_prefix_parts[:-1]) if len(raw_prefix_parts) > 1 else ""
+            )
+            prefix_name = self.sanitize_filename_component(
+                raw_prefix_parts[-1], default="ComfyUI"
+            )
+            filename_prefix = (
+                os.path.join(prefix_dir, prefix_name) if prefix_dir else prefix_name
+            )
+        else:
+            filename_prefix = "ComfyUI"
+
         subdirectory_name = self.sanitize_subdirectory_path(
             self.format_filename(subdirectory_name, pnginfo_dict or {})
         )

--- a/modules/nodes/node.py
+++ b/modules/nodes/node.py
@@ -152,6 +152,7 @@ class SaveImageWithMetaData:
             active[oid] = path
             try:
                 out = {}
+                seen_json_keys = {}
                 for key, item in value.items():
                     if isinstance(key, str):
                         json_key = key
@@ -165,6 +166,13 @@ class SaveImageWithMetaData:
                         json_key = str(key)
                     else:
                         raise TypeError(f"unsupported key type {type(key).__name__} at {path}")
+                    if json_key in seen_json_keys:
+                        prev_key = seen_json_keys[json_key]
+                        raise ValueError(
+                            f"duplicate JSON key {json_key!r} at {path} from "
+                            f"{prev_key!r} ({type(prev_key).__name__}) and {key!r} ({type(key).__name__})"
+                        )
+                    seen_json_keys[json_key] = key
                     out[json_key] = cls._normalize_json_value(item, f"{path}.{json_key}", active)
                 return out
             finally:
@@ -341,7 +349,7 @@ class SaveImageWithMetaData:
             except (TypeError, ValueError) as e:
                 print_warning(f"Skipping workflow JSON sidecar: {e}")
             else:
-                json_filename = last_image_filename.replace(base_format, "json")
+                json_filename = os.path.splitext(last_image_filename)[0] + ".json"
                 batch_json_file = os.path.join(full_output_folder, json_filename)
                 with open(batch_json_file, "w", encoding="utf-8") as f:
                     json.dump(workflow_json, f)

--- a/modules/nodes/node.py
+++ b/modules/nodes/node.py
@@ -1,4 +1,5 @@
 import json
+import math
 import os
 import re
 import unicodedata
@@ -139,7 +140,11 @@ class SaveImageWithMetaData:
         Reject recursive or unsupported structures instead of handing them
         directly to json.dump/json.dumps.
         """
-        if value is None or isinstance(value, (str, int, float, bool)):
+        if value is None or isinstance(value, (str, int, bool)):
+            return value
+        if isinstance(value, float):
+            if not math.isfinite(value):
+                raise ValueError(f"non-finite float at {path}")
             return value
 
         if active is None:
@@ -352,7 +357,7 @@ class SaveImageWithMetaData:
                 json_filename = os.path.splitext(last_image_filename)[0] + ".json"
                 batch_json_file = os.path.join(full_output_folder, json_filename)
                 with open(batch_json_file, "w", encoding="utf-8") as f:
-                    json.dump(workflow_json, f)
+                    json.dump(workflow_json, f, allow_nan=False)
 
         return {"ui": {"images": results}}
 
@@ -383,16 +388,18 @@ class SaveImageWithMetaData:
             except (TypeError, ValueError) as e:
                 print_warning(f"Skipping prompt metadata: {e}")
             else:
-                metadata.add_text("prompt", json.dumps(prompt_value))
+                metadata.add_text("prompt", json.dumps(prompt_value, allow_nan=False))
 
         if extra_pnginfo is not None:
             for x in extra_pnginfo:
+                if metadata_scope == MetadataScope.WORKFLOW_ONLY and x != "workflow":
+                    continue
                 try:
                     value = self._normalize_json_value(extra_pnginfo[x], f"extra_pnginfo[{x!r}]")
                 except (TypeError, ValueError) as e:
                     print_warning(f"Skipping metadata field '{x}': {e}")
                     continue
-                metadata.add_text(x, json.dumps(value))
+                metadata.add_text(x, json.dumps(value, allow_nan=False))
 
         return metadata
 

--- a/modules/nodes/node.py
+++ b/modules/nodes/node.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import unicodedata
 from datetime import datetime
 from pathlib import Path
 
@@ -115,6 +116,8 @@ class SaveImageWithMetaData:
     CATEGORY = "SaveImage"
 
     pattern_format = re.compile(r"(%[^%]+%)") # Pattern to match mask values in the filename
+    invalid_path_chars = re.compile(r'[<>:"|?*\x00-\x1f]')
+    whitespace_re = re.compile(r"\s+")
 
     def parse_output_format(self, output_format: str):
         fmt = OutputFormat(output_format)
@@ -145,6 +148,33 @@ class SaveImageWithMetaData:
         """Extracts placeholder segments like %seed%, %pprompt:32%, etc."""
         return re.findall(cls.pattern_format, filename) if "%" in filename else []
 
+    @classmethod
+    def sanitize_filename_component(cls, value, default="ComfyUI", max_length=160):
+        """Convert dynamic filename text into a single safe filename component."""
+        value = "" if value is None else str(value)
+        value = unicodedata.normalize("NFKC", value)
+        value = value.replace("/", "_").replace("\\", "_")
+        value = cls.invalid_path_chars.sub("_", value)
+        value = cls.whitespace_re.sub(" ", value).strip(" .")
+        return value[:max_length] or default
+
+    @classmethod
+    def sanitize_subdirectory_path(cls, value, max_component_length=80):
+        """Convert dynamic subdirectory text into a safe relative subdirectory path."""
+        value = "" if value is None else str(value)
+        value = unicodedata.normalize("NFKC", value)
+        raw_parts = re.split(r"[\\/]+", value)
+        parts = []
+        for part in raw_parts:
+            part = part.strip()
+            if not part or part in (".", ".."):
+                continue
+            safe = cls.invalid_path_chars.sub("_", part)
+            safe = cls.whitespace_re.sub(" ", safe).strip(" .")
+            if safe:
+                parts.append(safe[:max_component_length])
+        return os.path.join(*parts) if parts else ""
+
     def needs_pnginfo_in_filename(self, segments: list[str]) -> bool:
         for segment in segments:
             parts = segment.strip("%").split(":")
@@ -168,8 +198,13 @@ class SaveImageWithMetaData:
         if metadata_scope in [MetadataScope.FULL, MetadataScope.PARAMETERS_ONLY] or self.needs_pnginfo_in_filename(segments):
             pnginfo_dict = pnginfo_dict or self.gen_pnginfo(prompt, prefer_nearest)
 
-        filename_prefix = self.format_filename(filename_prefix, pnginfo_dict or {}, segments) + self.prefix_append
-        subdirectory_name = self.format_filename(subdirectory_name, pnginfo_dict or {})
+        filename_prefix = self.sanitize_filename_component(
+            self.format_filename(filename_prefix, pnginfo_dict or {}, segments) + self.prefix_append,
+            default="ComfyUI",
+        )
+        subdirectory_name = self.sanitize_subdirectory_path(
+            self.format_filename(subdirectory_name, pnginfo_dict or {})
+        )
 
 
         image_shape = images[0].shape
@@ -178,11 +213,9 @@ class SaveImageWithMetaData:
         )
 
         # Handle subdirectory naming and creation
-        subdirectory_name = subdirectory_name.strip()
         if subdirectory_name:
-            subdirectory_name = self.format_filename(subdirectory_name, pnginfo_dict)
             full_output_folder = os.path.join(self.output_dir, subdirectory_name)
-            filename = filename_prefix
+            filename = self.sanitize_filename_component(filename_prefix, default="ComfyUI")
 
         os.makedirs(full_output_folder, exist_ok=True)
 

--- a/modules/nodes/node.py
+++ b/modules/nodes/node.py
@@ -206,16 +206,11 @@ class SaveImageWithMetaData:
             self.format_filename(subdirectory_name, pnginfo_dict or {})
         )
 
-
         image_shape = images[0].shape
+        save_prefix = os.path.join(subdirectory_name, filename_prefix) if subdirectory_name else filename_prefix
         full_output_folder, filename, counter, subfolder, filename_prefix = folder_paths.get_save_image_path(
-            filename_prefix, self.output_dir, image_shape[1], image_shape[0]
+            save_prefix, self.output_dir, image_shape[1], image_shape[0]
         )
-
-        # Handle subdirectory naming and creation
-        if subdirectory_name:
-            full_output_folder = os.path.join(self.output_dir, subdirectory_name)
-            filename = self.sanitize_filename_component(filename_prefix, default="ComfyUI")
 
         os.makedirs(full_output_folder, exist_ok=True)
 
@@ -263,7 +258,7 @@ class SaveImageWithMetaData:
                 })
                 piexif.insert(exif_bytes, path)
 
-            results.append({"filename": file, "subfolder": full_output_folder, "type": self.type})
+            results.append({"filename": file, "subfolder": subfolder, "type": self.type})
 
         # Save workflow metadata for the batch
         if save_workflow_json and images_length > 0 and last_image_filename:

--- a/modules/nodes/node.py
+++ b/modules/nodes/node.py
@@ -133,6 +133,19 @@ class SaveImageWithMetaData:
             QualityOption.LOW: 30
         }.get(quality, 100)
 
+    @staticmethod
+    def build_workflow_json_payload(workflow):
+        """
+        Emit a sidecar JSON that works with ComfyUI variants that:
+        - accept a raw workflow document, and/or
+        - expect a top-level `workflow` field.
+        """
+        if not isinstance(workflow, dict):
+            return workflow
+        payload = dict(workflow)
+        payload.setdefault("workflow", workflow)
+        return payload
+
     @classmethod
     def _normalize_json_value(cls, value, path="$", active=None):
         """
@@ -357,7 +370,7 @@ class SaveImageWithMetaData:
                 json_filename = os.path.splitext(last_image_filename)[0] + ".json"
                 batch_json_file = os.path.join(full_output_folder, json_filename)
                 with open(batch_json_file, "w", encoding="utf-8") as f:
-                    json.dump(workflow_json, f, allow_nan=False)
+                    json.dump(self.build_workflow_json_payload(workflow_json), f, allow_nan=False)
 
         return {"ui": {"images": results}}
 

--- a/modules/nodes/node.py
+++ b/modules/nodes/node.py
@@ -3,7 +3,6 @@ import os
 import re
 import unicodedata
 from datetime import datetime
-from pathlib import Path
 
 import numpy as np
 import piexif
@@ -137,9 +136,20 @@ class SaveImageWithMetaData:
         """
         Finds the next available filename by checking existing files in the directory.
         """
-        existing = {f.stem for f in Path(folder).glob(f"{name}_*.{ext}")}
+        # `name` is a literal filename stem, not a glob pattern.
+        pattern = re.compile(rf"^{re.escape(name)}_(\d{{5}})\.{re.escape(ext)}$")
+        existing = set()
+        try:
+            with os.scandir(folder) as entries:
+                for entry in entries:
+                    match = pattern.match(entry.name)
+                    if match:
+                        existing.add(int(match.group(1)))
+        except FileNotFoundError:
+            return 1
+
         i = 1
-        while f"{name}_{i:05d}" in existing:
+        while i in existing:
             i += 1
         return i
 

--- a/modules/nodes/node.py
+++ b/modules/nodes/node.py
@@ -132,6 +132,56 @@ class SaveImageWithMetaData:
             QualityOption.LOW: 30
         }.get(quality, 100)
 
+    @classmethod
+    def _normalize_json_value(cls, value, path="$", active=None):
+        """
+        Convert foreign metadata into a detached plain JSON tree.
+        Reject recursive or unsupported structures instead of handing them
+        directly to json.dump/json.dumps.
+        """
+        if value is None or isinstance(value, (str, int, float, bool)):
+            return value
+
+        if active is None:
+            active = {}
+
+        if isinstance(value, dict):
+            oid = id(value)
+            if oid in active:
+                raise ValueError(f"circular reference detected at {path} (via {active[oid]})")
+            active[oid] = path
+            try:
+                out = {}
+                for key, item in value.items():
+                    if isinstance(key, str):
+                        json_key = key
+                    elif key is None:
+                        json_key = "null"
+                    elif key is True:
+                        json_key = "true"
+                    elif key is False:
+                        json_key = "false"
+                    elif isinstance(key, (int, float)):
+                        json_key = str(key)
+                    else:
+                        raise TypeError(f"unsupported key type {type(key).__name__} at {path}")
+                    out[json_key] = cls._normalize_json_value(item, f"{path}.{json_key}", active)
+                return out
+            finally:
+                active.pop(oid, None)
+
+        if isinstance(value, (list, tuple)):
+            oid = id(value)
+            if oid in active:
+                raise ValueError(f"circular reference detected at {path} (via {active[oid]})")
+            active[oid] = path
+            try:
+                return [cls._normalize_json_value(item, f"{path}[{idx}]", active) for idx, item in enumerate(value)]
+            finally:
+                active.pop(oid, None)
+
+        raise TypeError(f"unsupported value type {type(value).__name__} at {path}")
+
     def find_next_available_filename(self, folder: str, name: str, ext: str):
         """
         Finds the next available filename by checking existing files in the directory.
@@ -285,12 +335,16 @@ class SaveImageWithMetaData:
             results.append({"filename": file, "subfolder": subfolder, "type": self.type})
 
         # Save workflow metadata for the batch
-        if save_workflow_json and images_length > 0 and last_image_filename:
-            json_filename = last_image_filename.replace(base_format, "json")
-            batch_json_file = os.path.join(full_output_folder, json_filename)
-
-            with open(batch_json_file, "w", encoding="utf-8") as f:
-                json.dump(extra_pnginfo["workflow"], f)
+        if save_workflow_json and images_length > 0 and last_image_filename and extra_pnginfo is not None and "workflow" in extra_pnginfo:
+            try:
+                workflow_json = self._normalize_json_value(extra_pnginfo["workflow"], "extra_pnginfo.workflow")
+            except (TypeError, ValueError) as e:
+                print_warning(f"Skipping workflow JSON sidecar: {e}")
+            else:
+                json_filename = last_image_filename.replace(base_format, "json")
+                batch_json_file = os.path.join(full_output_folder, json_filename)
+                with open(batch_json_file, "w", encoding="utf-8") as f:
+                    json.dump(workflow_json, f)
 
         return {"ui": {"images": results}}
 
@@ -316,11 +370,21 @@ class SaveImageWithMetaData:
                         return metadata
 
         if prompt is not None and metadata_scope != MetadataScope.WORKFLOW_ONLY:
-            metadata.add_text("prompt", json.dumps(prompt))
+            try:
+                prompt_value = self._normalize_json_value(prompt, "prompt")
+            except (TypeError, ValueError) as e:
+                print_warning(f"Skipping prompt metadata: {e}")
+            else:
+                metadata.add_text("prompt", json.dumps(prompt_value))
 
         if extra_pnginfo is not None:
             for x in extra_pnginfo:
-                metadata.add_text(x, json.dumps(extra_pnginfo[x]))
+                try:
+                    value = self._normalize_json_value(extra_pnginfo[x], f"extra_pnginfo[{x!r}]")
+                except (TypeError, ValueError) as e:
+                    print_warning(f"Skipping metadata field '{x}': {e}")
+                    continue
+                metadata.add_text(x, json.dumps(value))
 
         return metadata
 

--- a/modules/nodes/node.py
+++ b/modules/nodes/node.py
@@ -281,7 +281,15 @@ class SaveImageWithMetaData:
         segments = self.parse_filename_placeholders(filename_prefix)
 
         if metadata_scope in [MetadataScope.FULL, MetadataScope.PARAMETERS_ONLY] or self.needs_pnginfo_in_filename(segments):
-            pnginfo_dict = pnginfo_dict or self.gen_pnginfo(prompt, prefer_nearest, unique_id)
+            if not pnginfo_dict:
+                try:
+                    pnginfo_dict = self.gen_pnginfo(prompt, prefer_nearest, unique_id)
+                except Exception as e:
+                    print_warning(
+                        "Extended metadata generation failed; saving image "
+                        f"without generated metadata: {e}"
+                    )
+                    pnginfo_dict = {}
 
         raw_filename_prefix = self.format_filename(
             filename_prefix, pnginfo_dict or {}, segments

--- a/modules/nodes/node.py
+++ b/modules/nodes/node.py
@@ -324,8 +324,9 @@ class SaveImageWithMetaData:
 
             # Prepare metadata
             metadata = self.prepare_pnginfo(PngInfo(), pnginfo_dict, batch_number, images_length, prompt, extra_pnginfo, metadata_scope)
-            for key, value in extra_metadata.items():
-                metadata.add_text(key, value)
+            if metadata is not None:
+                for key, value in extra_metadata.items():
+                    metadata.add_text(key, value)
 
             # Handle filename collision and batch number inclusion
             file = f"{filename}_{batch_number:05d}.{base_format}" if include_batch_num else f"{filename}.{base_format}"
@@ -417,9 +418,11 @@ class SaveImageWithMetaData:
 
     @classmethod
     def gen_pnginfo(s, prompt, prefer_nearest, unique_id=None):
-        save_node_id = unique_id if unique_id is not None else hook.current_save_image_node_id
+        if unique_id is None:
+            raise RuntimeError("SaveImageWithMetaData requires ComfyUI UNIQUE_ID to trace metadata inputs")
+
         inputs = Capture.get_inputs()
-        trace_tree_from_this_node = Trace.trace(save_node_id, prompt)
+        trace_tree_from_this_node = Trace.trace(unique_id, prompt)
         inputs_before_this_node = Trace.filter_inputs_by_trace_tree(inputs, trace_tree_from_this_node, prefer_nearest)
 
         sampler_node_id = Trace.find_sampler_node_id(trace_tree_from_this_node)

--- a/modules/nodes/node.py
+++ b/modules/nodes/node.py
@@ -281,7 +281,7 @@ class SaveImageWithMetaData:
         segments = self.parse_filename_placeholders(filename_prefix)
 
         if metadata_scope in [MetadataScope.FULL, MetadataScope.PARAMETERS_ONLY] or self.needs_pnginfo_in_filename(segments):
-            if not pnginfo_dict:
+            if pnginfo_dict is None:
                 try:
                     pnginfo_dict = self.gen_pnginfo(prompt, prefer_nearest, unique_id)
                 except Exception as e:

--- a/modules/nodes/node.py
+++ b/modules/nodes/node.py
@@ -105,7 +105,8 @@ class SaveImageWithMetaData:
             },
             "hidden": {
                 "prompt": "PROMPT",
-                "extra_pnginfo": "EXTRA_PNGINFO"
+                "extra_pnginfo": "EXTRA_PNGINFO",
+                "unique_id": "UNIQUE_ID"
             },
         }
 
@@ -271,18 +272,16 @@ class SaveImageWithMetaData:
     def save_images(self, images, filename_prefix="ComfyUI", subdirectory_name="", prompt=None,
                     extra_pnginfo=None, extra_metadata=None, output_format="png",
                     quality="max", metadata_scope="full",
-                    include_batch_num=True, prefer_nearest=True, pnginfo_dict=None):
+                    include_batch_num=True, prefer_nearest=True, pnginfo_dict=None, unique_id=None):
 
         extra_metadata = extra_metadata or {}
         base_format, save_workflow_json = self.parse_output_format(output_format)
-        pnginfo = PngInfo()
-
         # Parse filename
         filename_prefix = filename_prefix.strip()
         segments = self.parse_filename_placeholders(filename_prefix)
 
         if metadata_scope in [MetadataScope.FULL, MetadataScope.PARAMETERS_ONLY] or self.needs_pnginfo_in_filename(segments):
-            pnginfo_dict = pnginfo_dict or self.gen_pnginfo(prompt, prefer_nearest)
+            pnginfo_dict = pnginfo_dict or self.gen_pnginfo(prompt, prefer_nearest, unique_id)
 
         raw_filename_prefix = self.format_filename(
             filename_prefix, pnginfo_dict or {}, segments
@@ -324,7 +323,7 @@ class SaveImageWithMetaData:
             img = Image.fromarray(np.clip(i, 0, 255).astype(np.uint8))
 
             # Prepare metadata
-            metadata = self.prepare_pnginfo(pnginfo, pnginfo_dict, batch_number, images_length, prompt, extra_pnginfo, metadata_scope)
+            metadata = self.prepare_pnginfo(PngInfo(), pnginfo_dict, batch_number, images_length, prompt, extra_pnginfo, metadata_scope)
             for key, value in extra_metadata.items():
                 metadata.add_text(key, value)
 
@@ -417,9 +416,10 @@ class SaveImageWithMetaData:
         return metadata
 
     @classmethod
-    def gen_pnginfo(s, prompt, prefer_nearest):
+    def gen_pnginfo(s, prompt, prefer_nearest, unique_id=None):
+        save_node_id = unique_id if unique_id is not None else hook.current_save_image_node_id
         inputs = Capture.get_inputs()
-        trace_tree_from_this_node = Trace.trace(hook.current_save_image_node_id, prompt)
+        trace_tree_from_this_node = Trace.trace(save_node_id, prompt)
         inputs_before_this_node = Trace.filter_inputs_by_trace_tree(inputs, trace_tree_from_this_node, prefer_nearest)
 
         sampler_node_id = Trace.find_sampler_node_id(trace_tree_from_this_node)

--- a/modules/trace.py
+++ b/modules/trace.py
@@ -1,12 +1,25 @@
 from collections import deque, defaultdict
 from .defs.samplers import SAMPLERS
 from .utils.log import print_warning
+from comfy_execution.graph_utils import is_link
 
 class Trace:
     _trace_cache = {}
 
     @staticmethod
+    def _extract_upstream_node_id(value, prompt):
+        """Return the upstream node id for a real ComfyUI prompt link, else None."""
+        if not is_link(value):
+            return None
+        node_id = value[0]
+        if node_id not in prompt:
+            return None
+
+        return node_id
+
+    @staticmethod
     def _bfs_traverse(start_node_id, prompt, visit_node, edge_condition=None):
+        start_node_id = str(start_node_id)
         Q = deque([(start_node_id, 0)])
         visited_nodes = set()
         visited_edges = set()
@@ -21,43 +34,36 @@ class Trace:
             visit_node(current_node_id, node, distance)
 
             for value in node.get("inputs", {}).values():
-                if isinstance(value, list):
-                    values = value
-                else:
-                    values = [value]
+                next_id = Trace._extract_upstream_node_id(value, prompt)
+                if next_id is None:
+                    continue
 
-                for next_id in values:
-                    if next_id is None:
-                        continue
+                edge = (current_node_id, next_id)
+                if edge in visited_edges or (edge_condition and not edge_condition(current_node_id, next_id)):
+                    continue
 
-                    # Handle dict-based links (ComfyUI internal link structures)
-                    if isinstance(next_id, dict):
-                        next_id = next_id.get("link") or next_id.get("id") or next_id.get("node_id")
-
-                    # Skip if still invalid
-                    if next_id is None or isinstance(next_id, dict):
-                        continue
-
-                    next_id = str(next_id) if isinstance(next_id, int) else next_id
-
-                    edge = (current_node_id, next_id)
-                    if edge in visited_edges or (edge_condition and not edge_condition(current_node_id, next_id)):
-                        continue
-
-                    visited_edges.add(edge)
-                    Q.append((next_id, distance + 1))
+                visited_edges.add(edge)
+                Q.append((next_id, distance + 1))
 
     @classmethod
     def _compute_trace_signature(cls, start_node_id, prompt):
         structure = []
+
         def collect_structure(nid, node, _):
-            structure.append((nid, node.get("class_type", "")))
+            upstream = []
+            for value in node.get("inputs", {}).values():
+                next_id = cls._extract_upstream_node_id(value, prompt)
+                if next_id is not None:
+                    upstream.append(next_id)
+            structure.append((nid, node.get("class_type", ""), tuple(sorted(upstream))))
+
         cls._bfs_traverse(start_node_id, prompt, collect_structure)
         structure.sort()
-        return hash(tuple(structure))
+        return (str(start_node_id), tuple(structure))
 
     @classmethod
     def trace(cls, start_node_id, prompt):
+        start_node_id = str(start_node_id)
         sig = cls._compute_trace_signature(start_node_id, prompt)
         if sig in cls._trace_cache:
             return cls._trace_cache[sig]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui_image_metadata_extension"
 description = "Custom node for ComfyUI. It adds additional metadata for saved images, ensuring compatibility with the Civitai website."
-version = "1.3.4"
+version = "1.3.5"
 license = { file = "LICENSE" }
 
 [project.urls]
@@ -9,6 +9,6 @@ Repository = "https://github.com/edelvarden/comfyui_image_metadata_extension"
 #  Used by Comfy Registry https://comfyregistry.org
 
 [tool.comfy]
-PublisherId = "edelvarden"
+PublisherId = "xmarre"
 DisplayName = "comfyui_image_metadata_extension"
 Icon = ""


### PR DESCRIPTION
## Title

Fix cache compatibility in `capture.py` and sanitize dynamic save paths for newer ComfyUI

## Summary

This updates the extension in two places:

1. `modules/capture.py`: fixes synchronous cache access so metadata capture no longer calls async cache accessors from synchronous code paths.
2. `modules/nodes/node.py`: sanitizes dynamically formatted filename and subdirectory values before handing them to ComfyUI’s save-path helpers.

These address two distinct failures seen with newer ComfyUI builds and dynamic save-path usage:

- coroutine objects leaking into metadata capture / execution paths
- intermittent crashes during save-path construction when dynamic prompt/model text is used in filenames or subdirectories

The extension issue tracker already has reports in this family, and there is also already an open PR in this repo specifically about invalid characters in prompt-derived filenames. :contentReference[oaicite:0]{index=0}

## Problem

### 1. Async cache access from synchronous metadata capture

`OutputCacheCompat` currently assumes that if the cache object has a `.get()` method, it is safe to call it synchronously.

That assumption no longer holds on newer ComfyUI versions.

As a result, metadata capture can return coroutine objects instead of cache entries, which then causes downstream failures such as:

- `'coroutine' object has no attribute 'outputs'`
- `'coroutine' object has no attribute 'ui'`

### 2. Unsanitized dynamic filename / subdirectory formatting

The save node supports prompt/model/date/etc. placeholders in `filename_prefix` and `subdirectory_name`.

Those formatted values were being passed through too trustingly. In real workflows, prompt- or model-derived text can contain path separators, invalid filename characters, control characters, traversal fragments, or overly long path components. That can destabilize path construction and save behavior.

## Root cause

### Cache side

The compatibility layer in `modules/capture.py` was written around older cache APIs where calling `.get()` synchronously was fine.

On newer ComfyUI versions:

- `get()` may be async
- `get_local()` is the correct synchronous accessor for local cache lookups

Because metadata capture runs through synchronous code here, calling async `get()` poisons the returned value and breaks later execution paths.

### Save-path side

Dynamic text from placeholders was being used directly to build save names and subdirectories.

That means user prompt text, model names, or other metadata-derived values could be interpreted as path structure instead of plain filename content, or could contain invalid / problematic characters that should have been normalized before being passed into ComfyUI’s save helpers.

## Changes

### 1. Fix synchronous cache access in `modules/capture.py`

This patch adds a single internal helper, `_lookup_cached()`, and routes all cache access through it.

Lookup order:

1. Prefer `get_local()` when present
2. Fall back to `get_cache()` when present
3. Fall back to `get()` only if its return value is not awaitable
4. Finally fall back to legacy `outputs[...]` access

This keeps the compatibility shim working across older and newer ComfyUI versions without leaking awaitables into synchronous metadata capture.

### 2. Sanitize dynamic save-path inputs in `modules/nodes/node.py`

This patch adds dedicated sanitization for:

- `filename_prefix` as a single filename component
- `subdirectory_name` as a safe relative subdirectory path

The sanitization now:

- normalizes Unicode
- replaces path separators in filename components
- removes invalid filename characters and control characters
- collapses excessive whitespace
- strips leading/trailing spaces and dots
- removes `.` / `..` traversal fragments from subdirectory paths
- bounds filename/path component length

This keeps directory structure in `subdirectory_name` and prevents placeholder-expanded metadata text from behaving like an unsafe or malformed path.

## Why this approach

This keeps both fixes narrowly scoped to the extension’s own compatibility and save-path handling layers.

The goal is not to change how metadata is collected or how placeholders work. The goal is to make the extension safe and version-compatible when:

- ComfyUI cache accessors change
- dynamic placeholder content contains text that is not path-safe

## Result

With this patch applied:

- metadata capture no longer calls async cache accessors unsafely
- coroutine objects no longer leak into downstream execution from `capture.py`
- dynamic filename/subdirectory formatting is constrained to safe path content
- intermittent save-time crashes caused by malformed dynamic filename/path text are avoided
- older compatibility fallbacks remain intact

## Required ComfyUI version / how affected users should update

This patch fixes the extension-side issues in `modules/capture.py` and `modules/nodes/node.py`.

However, users on older ComfyUI release builds can still hit a separate core cache-path problem that was fixed later upstream. In practice, users who are still on release-tag installs such as `v0.17.1` may need to update ComfyUI itself to the current development branch to get the full fix path.

ComfyUI’s official update docs explicitly distinguish between stable and development update paths for manual, portable, and desktop installs. They also document `git checkout master` as the way to return to the latest development version, and note that Desktop is based on stable releases and may lag behind newer upstream fixes. :contentReference[oaicite:1]{index=1}

### How to update ComfyUI to the upstream core fixes

#### Manual / git installation

Use the current development branch instead of the stable release tag:

```bash
cd <ComfyUI_ROOT_PATH>
git checkout master
git pull
pip install -r requirements.txt